### PR TITLE
Remove logo and options when printing the page

### DIFF
--- a/src/GitHub.less
+++ b/src/GitHub.less
@@ -2,4 +2,8 @@
   position: fixed;
   top: 36px;
   right: 20px;
+
+  @media print {
+    display: none;
+  }
 }

--- a/src/Options.less
+++ b/src/Options.less
@@ -17,6 +17,10 @@
     user-select: none;
   }
 
+  @media print {
+    display: none;
+  }
+
   @media screen and (max-width: 780px) {
     margin-left: 0;
     margin-right: 0;


### PR DESCRIPTION
## Before:
<img width="1153" alt="image" src="https://user-images.githubusercontent.com/613647/41820161-6de14c62-77cd-11e8-9cdc-6d07da7aea10.png">


## After:
<img width="1277" alt="image" src="https://user-images.githubusercontent.com/613647/41820151-4dfffc54-77cd-11e8-9fcc-1f724c6fb3e1.png">
