### PR TITLE
Improve Japanese translation

### DIFF
--- a/src/i18n/json/ja-JP.json
+++ b/src/i18n/json/ja-JP.json
@@ -6,14 +6,14 @@
   "Language": "言語",
   "Mounting": "マウント時",
   "Updating": "更新時",
-  "Unmounting": "マウント解除時",
-  "“{name} phase”": "“{name} ステージ”",
+  "Unmounting": "アンマウント時",
+  "“{name} phase”": "“{name} フェーズ”",
   "Pure and has no side effects. May be paused, aborted or restarted by React.": "純粋で副作用を持たない。Reactによって一時停止、中断、再スタートされることがある",
   "Can read the DOM.": "DOMを読み取り可能",
   "Can work with DOM, run side effects, schedule updates.": "DOMに働きかけることができる。副作用があり、更新タイミングを決める",
   "React updates DOM and refs": "Reactが DOM と refs を更新する",
-  "Read docs for {name} (opens in a new tab)": "ドキュメント {name} を読む（新しいタブで開きます）",
+  "Read docs for {name} (opens in a new tab)": "{name} のドキュメントを読む（新しいタブで開く）",
   "//reactjs.org/docs/react-component.html#{docname}": "//ja.reactjs.org/docs/react-component.html#{docname}",
-  "See project's page on GitHub (opens in a new tab)": "Github上のプロジェクトページを見る(新しいタブで開きます)",
+  "See project's page on GitHub (opens in a new tab)": "GitHub上のプロジェクトページを見る(新しいタブで開く)",
   "See project on": "プロジェクトを見る@"
 }


### PR DESCRIPTION
- Correct common typos
  - Github -> GitHub
- Use words from official documents
  - `マウント解除` -> `アンマウント` [^1]
  - `ステージ` -> `フェーズ` [^2]
- Correct the word order
  - `ドキュメント {name} を読む` -> `{name} のドキュメントを読む`
- Unify writing style into Japanese regular style (*)
  - `新しいタブで開きます` -> `新しいタブで開く`

(*) Japanese sentences are mainly divided into the regular style and the honorific style. Here, we will use the regular style to match the rest of the text. [^3]

[^1]: https://ja.reactjs.org/docs/react-component.html#unmounting
[^2]: https://ja.reactjs.org/docs/strict-mode.html#detecting-unexpected-side-effects
[^3]: https://ja.wikipedia.org/wiki/%E6%97%A5%E6%9C%AC%E8%AA%9E#%E6%99%AE%E9%80%9A%E4%BD%93%E3%83%BB%E4%B8%81%E5%AF%A7%E4%BD%93