### PR TITLE
Improve ko-Kr translation

### DIFF
--- a/src/i18n/json/ko-KR.json
+++ b/src/i18n/json/ko-KR.json
@@ -11,7 +11,7 @@
   "Pure and has no side effects. May be paused, aborted or restarted by React.": "순수하고 부작용이 없습니다. React에 의해 일시 중지, 중단 또는 재시작 될 수 있습니다",
   "Can read the DOM.": "DOM을 읽을 수 있습니다.",
   "Can work with DOM, run side effects, schedule updates.": "DOM을 사용하여 부작용을 실행하고 업데이트를 예약 할 수 있습니다.",
-  "React updates DOM and refs": "React DOM 및 refs 업데이트",
+  "React updates DOM and refs": "React가 DOM 및 refs를 업데이트",
   "Read docs for {name} (opens in a new tab)": "{name}에 대한 설명서를 읽습니다 (새 탭에서 열림).",
   "//reactjs.org/docs/react-component.html#{docname}": "//ko.reactjs.org/docs/react-component.html#{docname}",
   "See project's page on GitHub (opens in a new tab)": "GitHub에서 프로젝트 페이지를 봅니다 (새 탭에서 열림).",


### PR DESCRIPTION
I found some awkward translation to be fixed! please check and leave me some msg if there's an issue 😊

[before]
"React DOM 및 refs 업데이트" refers to "updates React DOM and refs" which isn't correct explanation.

[after]
"React가 DOM 및 refs를 업데이트" refers to "React updates DOM and refs" which I think is more accurate explanation