### PR TITLE
Fix incorrect translation for unmounting in Arabic

### DIFF
--- a/src/i18n/json/ar-AE.json
+++ b/src/i18n/json/ar-AE.json
@@ -6,7 +6,7 @@
   "Language": "اللغة",
   "Mounting": "التركيب",
   "Updating": "التـحديـث",
-  "Unmounting": "عدم التركيب",
+  "Unmounting": "إزالة التركيب",
   "“{name} phase”": "“مرحلة {name}”",
   "Pure and has no side effects. May be paused, aborted or restarted by React.": "نقية وليس لها أثار جانبية. قد يتم إيقافها مؤقتاً أو إجهاضها أو إعادة تشغيلها بواسطة React",
   "Can read the DOM.": "يمكنها قراءة DOM.",


### PR DESCRIPTION
Fix incorrect translation for unmounting which makes it clear and more specific.

The previous translation meant "do not mount".
The new one means "Remove mounting / unmounting".