### PR TITLE
Prevent overwriting default with a translation

### DIFF
--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -5,6 +5,7 @@ export const languageFiles = {
   'be-BY': async () => (await import('./json/be-BY.json')).default,
   'bn-BD': async () => (await import('./json/bn-BD.json')).default,
   'de-DE': async () => (await import('./json/de-DE.json')).default,
+  'en-US': async () => (await import('./json/en-US.json')).default,
   'es-ES': async () => (await import('./json/es-ES.json')).default,
   'fa-IR': async () => (await import('./json/fa-IR.json')).default,
   'fr-FR': async () => (await import('./json/fr-FR.json')).default,
@@ -31,4 +32,6 @@ export const languageFiles = {
   'zh-Hant': async () => (await import('./json/zh-Hant.json')).default,
 };
 
-export const supportedLocales = [defaultLocale].concat(Object.keys(languageFiles));
+export const supportedLocales = [defaultLocale].concat(
+  Object.keys(languageFiles).filter((x) => x !== defaultLocale),
+);

--- a/src/i18n/json/en-US.json
+++ b/src/i18n/json/en-US.json
@@ -1,0 +1,16 @@
+{
+  "React lifecycle methods diagram": "React lifecycle methods diagram",
+  "Options": "Options",
+  "Show less-common lifecycles": "Show less-common lifecycles",
+  "Mounting": "Mounting",
+  "Updating": "Updating",
+  "Unmounting": "Unmounting",
+  "“{name} phase”": "“{name} phase”",
+  "Pure and has no side effects. May be paused, aborted or restarted by React.": "Pure and has no side effects. May be paused, aborted or restarted by React.",
+  "Can read the DOM.": "Can read the DOM.",
+  "Can work with DOM, run side effects, schedule updates.": "Can work with DOM, run side effects, schedule updates.",
+  "React updates DOM and refs": "React updates DOM and refs",
+  "Read docs for {name} (opens in a new tab)": "Read docs for {name} (opens in a new tab)",
+  "//reactjs.org/docs/react-component.html#{docname}": "//reactjs.org/docs/react-component.html#{docname}",
+  "See project's page on GitHub (opens in a new tab)": "See project's page on GitHub (opens in a new tab)"
+}


### PR DESCRIPTION
Hi :)


In some cases, the default (en-US) language version is being overwritten by a translation - instead of setting the language to user's language in the Options dropdown, the 'English (US) version is being replaced with the user's language.

Here's a screenshot of how that situation looked for me:
![description of the problem](https://github.com/user-attachments/assets/47a64b67-84cb-4414-a406-aea0bbc55a37)


This situation seems to not be desired, as now the English translation is not accessible - in the case from the screenshot, both English and Polish options show a Polish translation, with no way to show the English version. This can easily lead to the user not being able to access a version of the site understandable to them, if the user's preferred language has not been recognized correctly.

In my particular case:
- the language in which i wished to view the site was English
- my system locale was en-US
- my preferred languages set in the browser (firefox) were, in order: en, en-US, pl

In my case the site was exhibiting the behavior described above - English version was replaced with Polish, with no way to access the English version.
Removing Polish from the list of my languages in firefox made the site show up correctly in English.

This pull request fixes the issue by adding an English language file. With this fix, in my case, the English language option is no longer being overwritten. 
In case where the translation is actually needed (it is set in locale) already existing code changes the value of the language selection to user locale.

There is a very similar pull request open (https://github.com/wojtekmaj/react-lifecycle-methods-diagram/pull/188), which has not been merged, i assume due to not explaining why it is needed.